### PR TITLE
L-187: Form Templates | Syntax Error

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -6,13 +6,13 @@
     {{ form.hidden_tag() }}
     <p>
         {{ form.username.label }} <br>
-        {{ form.username.(size=32) }}
+        {{ form.username(size=32) }}
     </p>
     <p>
         {{ form.password.label }} <br>
         {{ form.password( size=32 )}}
     </p>
-    <p> {{ form.remember_me() }} {{ form.remeber_me.label }}</p>
+    <p> {{ form.remember_me() }} {{ form.remember_me.label }}</p>
     <p>{{ form.submit() }}</p>
 </form>
 {% endblock %}


### PR DESCRIPTION
What was changed?
-
    MODIFIED: login.html

Why was it changed?
-
    login.html

- RuntimeError: jinja2.exceptions.TemplateSyntaxError: expected name or number

More info:

No HTML fields exist in this template. This is because the fields from the form object know how to render themselves as HTML. The FieldForm fields derive from FlaskForm, a Flask-specific subclass of WTForms Form, a declarative Form base class using`{{ form.<field_name>.label }}`. For fields that require additional HTML attributes, those can be passed as arguments, `{{ form.<field_name>()}}`. The username and password fields in this template take the size as an argument that will be added to the <input> HTML element as an attribute: `{{ form.username(size=32) }}`. 

It is confirmed a syntax error was made.


- jinja2.exceptions.UndefinedError: 'app.forms.LoginForm object' has no attribute 'remeber_me'

Using the information above, field_names derive from the LoginForm class called within the view function. Investigating, the class, no `remeber_me`variable is assigned to a field. However, a `remember_me` variable does exist. Therefore it is confirmed a syntax error was mde. 


How was it changed?
-
    login.html

Change 1:

        {{ form.username.(size=32) }}
        {{ form.username(size=32) }}

-----
Change 2:

    <p> {{ form.remember_me() }} {{ form.remeber_me.label }}</p>
    <p> {{ form.remember_me() }} {{ form.remember_me.label }}</p>

