### PR TITLE
L-257: Shell Context

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,1 @@
+FLASK_APP=microblog.py

--- a/microblog.py
+++ b/microblog.py
@@ -1,1 +1,6 @@
-from app import app
+from app import app, db
+from app.models import User, Post
+
+@app.shell_context_processor
+def make_shell_context():
+    return {'db': db, 'User': User, 'Post': Post}


### PR DESCRIPTION
What was changed?
-
    MODIFIED: microblog.py
    ADDED: .flaskenv


Why was it changed?
-
    MODIFIED: microblog.py

>  To prevent repeating the same action when accessing the python interpreter, importing the app and, db, user and post. So, when next running `flask shell` to test the application, to start a Python interpreter in the context of the application, the command pre-imports the application instance. 

> The `app.shell_context_processor` decorator registers the function as a shell context function. When the flask shell command runs, it will invoke this function and register the items returned by it in the shell session. The reason the function returns a dictionary and not a list is that for each item one has to also provide a name under which it will be referenced in the shell, which is given by the dictionary keys.

> After, one adds the shell context processor function they can work with database entities without having to import them

Why was it changed?
-

    ADDED: .flaskenv

> Since environment variables aren't remembered across terminal sessions, it is tedious to always have to set the FLASK_APP environment variable when one opens a new terminal window. A `.flaskenv` file was created located in the top-level directory with the desired environment variable for it to be imported against the application when the flask command is run. The python-dotenv library is required. 

