### PR TITLE
L-294: Logging user out function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.extensionOutputFolder": "./.vscode"
-}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This README is structured like this:
 - User Login ([Flask-Login](https://flask-login.readthedocs.io/en/latest/))
   - Authentication (UserMixin)
   - Logging in (`current_user()`, `login_user()`)
+  - Logging out (`logout_user`)
 
 #### DevOps Practices Exercised
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,5 @@
 from flask import render_template, flash, redirect, url_for
-from flask_login import current_user,login_user
+from flask_login import current_user,login_user, logout_user
 from app import app
 from app.forms import LoginForm
 from app.models import User
@@ -34,6 +34,12 @@ def login():
         login_user(user, remember=form.remember_me.data)
         return redirect(url_for('index'))
     return render_template('login.html', title='Sign In', form=form)
+
+@app.route('/logout')
+def logout():
+    def logout():
+        logout_user()
+    return redirect(url_for('index'))
 
 if __name__ == '__main__':
     app.run()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,8 +10,12 @@
         <div>
             Microblog:
             <a href="{{ url_for('index') }}">Home</a>
+            {% if current_user.is_anonymous %}
             <a href="{{ url_for('login') }}">Login</a>
-        </div>
+            {% else %}
+            <a href="{{ url_for('logout') }}">Logout</a>
+            {% endif %}
+        </div>    
         <hr>
         {% with messages = get_flashed_messages() %}
         {% if messages %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -326,6 +326,17 @@ soupsieve = ">=1.8"
 wcmatch = ">=6.0.3"
 
 [[package]]
+name = "python-dotenv"
+version = "0.20.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -443,7 +454,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "de4fdb2008bef656d5569d8528e0139ee523c21f3137161ffd8d2b485acc4a8b"
+content-hash = "abcd2bdf3724c2b8a778fb437ec05c88a66209ddc1d79fce18af9c80d618b0cc"
 
 [metadata.files]
 alembic = [
@@ -708,6 +719,10 @@ pylev = [
 pyspelling = [
     {file = "pyspelling-2.8.1-py3-none-any.whl", hash = "sha256:8465b5a2bbd81094e5f3245ff431227f3f76b3667f9041e8d0881a68cdbfc24b"},
     {file = "pyspelling-2.8.1.tar.gz", hash = "sha256:eabe87bb72d5d0f02c1b5c3a16af9b6c6691eb26901db1c525c3cfe59dbb639d"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.20.0.tar.gz", hash = "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f"},
+    {file = "python_dotenv-0.20.0-py3-none-any.whl", hash = "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ Flask-Migrate = "^3.1.0"
 lxml = "4.9.1"
 cleo = "^0.8.1"
 Flask-Login = "^0.6.2"
+python-dotenv = "^0.20.0"
 
 [tool.poetry.dev-dependencies]
 Flask = "^2.1.1"


### PR DESCRIPTION
What was changed?
-
    modified:   app/routes.py
    modified:   app/templates/base.html
    modified:   poetry.lock
    modified:   pyproject.toml
    deleted:    .vscode/settings.json
    modified:   README.md

Why was it changed?
-
    MODIFIED:   app/routes.py

>  This PR detailed the logout functionality of routes.py. It provided the feature of the user logging out feature. This was done with the `logout_user()`. It was a simple implementation of where the function was implemented within the desired route, a new route `(/'logout')`. When users visit this route, they are redirected to the `index` function. 

    modified:   app/templates/base.html
> The base template was updated with three new functionalities, if the user is anonymous (not logged in), it will call the index function, or else what was accounted for whilst logging in or logging out (in case of an error). In the future, there will be specific error messages. 

    modified:   poetry.lock
    modified:   pyproject.toml

> Autogenerated by poetry. `python-dotenv` helps read key-value pairs. It is also a great choice for calling variables when a user wants to set environment variables and execute the program within the shell (for testing and other purposes).

    deleted:    .vscode/settings.json
> Not required to be public, it's a state copy file of my settings. 

    modified:   README.md
> To keep users updated. 
  